### PR TITLE
Publish release #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
    }
 
    group = 'com.ngc.seaside'
-   version = '2.23.0'
+   version = '2.24.0-SNAPSHOT'
 
    // Required in order to use implementation and api dependencies with groovy
    configurations {


### PR DESCRIPTION
Fixes #3 

Arifacts have been published as v2.23.0 at https://github.com/orgs/NorthropGrumman/packages?repo_name=seaside-gradle-plugins